### PR TITLE
Fix version intialization (if no versions were previously deployed)

### DIFF
--- a/src/main/java/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicy.java
+++ b/src/main/java/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicy.java
@@ -94,14 +94,19 @@ public class ArtifactoryVersionPolicy implements VersionPolicy, CurrentVersion {
                 stream.close();
             }
         } catch (FileNotFoundException e) {
-            currentVersion = "0"; //mavenProject.getVersion().replace("-SNAPSHOT", "");
+            currentVersion = null;
         } catch (IOException e) {
             throw new PolicyException("Unable to access " + urlString, e);
         }
-        final VersionInfo versionInfo = new DefaultVersionInfo(currentVersion);
-        final VersionInfo nextVersion = versionInfo.getNextVersion();
+        final VersionInfo nextVersion;
+        if(currentVersion == null) {
+            nextVersion = new DefaultVersionInfo("0");
+        } else {
+            DefaultVersionInfo versionInfo = new DefaultVersionInfo(currentVersion);
+            nextVersion = versionInfo.getNextVersion();
+        }
         final VersionInfo currentSnapshot = new DefaultVersionInfo(mavenProject.getVersion());
-        if (versionInfo.compareTo(currentSnapshot) <= 0) {
+        if (nextVersion.compareTo(currentSnapshot) < 0) {
             versionPolicyResult.setVersion(currentSnapshot.getReleaseVersionString() + ".0");
         } else {
             versionPolicyResult.setVersion(nextVersion.getReleaseVersionString());

--- a/src/main/java/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicy.java
+++ b/src/main/java/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicy.java
@@ -101,7 +101,7 @@ public class ArtifactoryVersionPolicy implements VersionPolicy, CurrentVersion {
         final VersionInfo versionInfo = new DefaultVersionInfo(currentVersion);
         final VersionInfo nextVersion = versionInfo.getNextVersion();
         final VersionInfo currentSnapshot = new DefaultVersionInfo(mavenProject.getVersion());
-        if (nextVersion.compareTo(currentSnapshot) < 0) {
+        if (versionInfo.compareTo(currentSnapshot) <= 0) {
             versionPolicyResult.setVersion(currentSnapshot.getReleaseVersionString() + ".0");
         } else {
             versionPolicyResult.setVersion(nextVersion.getReleaseVersionString());

--- a/src/test/groovy/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicyTest.groovy
+++ b/src/test/groovy/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicyTest.groovy
@@ -88,10 +88,10 @@ class ArtifactoryVersionPolicyTest extends Specification implements AbstractVers
 
         where:
         snapShotVersion | releaseVersion | currentVersion
-        '1.6-SNAPSHOT'  | '1.6.0'        | '0'
-        '2-SNAPSHOT'    | '2.0'          | '0'
-        '2.0-SNAPSHOT'  | '2.0.0'        | '0'
-        '1-SNAPSHOT'    | '1.0'          | '0'
+        '1.6-SNAPSHOT'  | '1.6.0'        | null
+        '2-SNAPSHOT'    | '2.0'          | null
+        '2.0-SNAPSHOT'  | '2.0.0'        | null
+        '1-SNAPSHOT'    | '1.0'          | null
 
     }
 

--- a/src/test/groovy/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicyTest.groovy
+++ b/src/test/groovy/net/oneandone/maven/shared/versionpolicies/ArtifactoryVersionPolicyTest.groovy
@@ -91,6 +91,7 @@ class ArtifactoryVersionPolicyTest extends Specification implements AbstractVers
         '1.6-SNAPSHOT'  | '1.6.0'        | '0'
         '2-SNAPSHOT'    | '2.0'          | '0'
         '2.0-SNAPSHOT'  | '2.0.0'        | '0'
+        '1-SNAPSHOT'    | '1.0'          | '0'
 
     }
 


### PR DESCRIPTION
When there are no versions deployed yet, the following happens:
```
currentVersion = "0"
versionInfo = 0
nextVersion = 1
currentSnapshot = 1-SNAPSHOT
versionPolicyResult = 1
```

However, I would expect that `versionPolicyResult` is `1.0`. The PR should fix the problem.

If I can find some time, I will add some tests! :)

Kind regards
